### PR TITLE
Fixed starting/ending date

### DIFF
--- a/INSElectronicProgramGuideLayout/INSElectronicProgramGuideLayout.h
+++ b/INSElectronicProgramGuideLayout/INSElectronicProgramGuideLayout.h
@@ -146,7 +146,6 @@ typedef NS_ENUM(NSUInteger, INSElectronicProgramGuideLayoutType) {
 
 @end
 
-
 @protocol INSElectronicProgramGuideLayoutDataSource <UICollectionViewDataSource>
 @required
 - (NSDate *)collectionView:(UICollectionView *)collectionView layout:(INSElectronicProgramGuideLayout *)electronicProgramGuideLayout startTimeForItemAtIndexPath:(NSIndexPath *)indexPath;
@@ -154,6 +153,9 @@ typedef NS_ENUM(NSUInteger, INSElectronicProgramGuideLayoutType) {
 - (NSDate *)collectionView:(UICollectionView *)collectionView layout:(INSElectronicProgramGuideLayout *)electronicProgramGuideLayout endTimeForItemAtIndexPath:(NSIndexPath *)indexPath;
 
 - (NSDate *)currentTimeForCollectionView:(UICollectionView *)collectionView layout:(INSElectronicProgramGuideLayout *)collectionViewLayout;
+@optional
+- (NSDate *)fixedStartTimeForcollectionView:(UICollectionView *)collectionView layout:(INSElectronicProgramGuideLayout *)electronicProgramGuideLayout;
+- (NSDate *)fixedEndTimeForcollectionView:(UICollectionView *)collectionView layout:(INSElectronicProgramGuideLayout *)electronicProgramGuideLayout;
 @end
 
 @protocol INSElectronicProgramGuideLayoutDelegate <UICollectionViewDelegate>

--- a/INSElectronicProgramGuideLayout/INSElectronicProgramGuideLayout.m
+++ b/INSElectronicProgramGuideLayout/INSElectronicProgramGuideLayout.m
@@ -830,11 +830,15 @@ NSUInteger const INSEPGLayoutMinBackgroundZ = 0.0;
         return self.cachedEarliestDate;
     }
     NSDate *earliestDate = nil;
-
-    for (NSInteger section = 0; section < self.collectionView.numberOfSections; section++) {
-        NSDate *earliestDateForSection = [self earliestDateForSection:section];
-        if ((earliestDateForSection && [earliestDateForSection ins_isEarlierThan:earliestDate]) || !earliestDate) {
-            earliestDate = earliestDateForSection;
+    
+    if ([self.dataSource respondsToSelector:@selector(fixedStartTimeForcollectionView:layout:)]) {
+        earliestDate = [self.dataSource fixedStartTimeForcollectionView:self.collectionView layout:self];
+    } else {
+        for (NSInteger section = 0; section < self.collectionView.numberOfSections; section++) {
+            NSDate *earliestDateForSection = [self earliestDateForSection:section];
+            if ((earliestDateForSection && [earliestDateForSection ins_isEarlierThan:earliestDate]) || !earliestDate) {
+                earliestDate = earliestDateForSection;
+            }
         }
     }
 
@@ -854,11 +858,15 @@ NSUInteger const INSEPGLayoutMinBackgroundZ = 0.0;
 
     NSDate *earliestDate = nil;
 
-    for (NSInteger item = 0; item < [self.collectionView numberOfItemsInSection:section]; item++) {
-        NSIndexPath *indexPath = [NSIndexPath indexPathForItem:item inSection:section];
-        NSDate *itemStartDate = [self startDateForIndexPath:indexPath];
-        if ((itemStartDate && [itemStartDate ins_isEarlierThan:earliestDate]) || !earliestDate) {
-            earliestDate = itemStartDate;
+    if ([self.dataSource respondsToSelector:@selector(fixedStartTimeForcollectionView:layout:)]) {
+        earliestDate = [self.dataSource fixedStartTimeForcollectionView:self.collectionView layout:self];
+    } else {
+        for (NSInteger item = 0; item < [self.collectionView numberOfItemsInSection:section]; item++) {
+            NSIndexPath *indexPath = [NSIndexPath indexPathForItem:item inSection:section];
+            NSDate *itemStartDate = [self startDateForIndexPath:indexPath];
+            if ((itemStartDate && [itemStartDate ins_isEarlierThan:earliestDate]) || !earliestDate) {
+                earliestDate = itemStartDate;
+            }
         }
     }
 
@@ -877,10 +885,14 @@ NSUInteger const INSEPGLayoutMinBackgroundZ = 0.0;
     }
     NSDate *latestDate = nil;
 
-    for (NSInteger section = 0; section < self.collectionView.numberOfSections; section++) {
-        NSDate *latestDateForSection = [self latestDateForSection:section];
-        if ((latestDateForSection && [latestDateForSection ins_isLaterThan:latestDate]) || !latestDate) {
-            latestDate = latestDateForSection;
+    if ([self.dataSource respondsToSelector:@selector(fixedEndTimeForcollectionView:layout:)]) {
+        latestDate = [self.dataSource fixedEndTimeForcollectionView:self.collectionView layout:self];
+    } else {
+        for (NSInteger section = 0; section < self.collectionView.numberOfSections; section++) {
+            NSDate *latestDateForSection = [self latestDateForSection:section];
+            if ((latestDateForSection && [latestDateForSection ins_isLaterThan:latestDate]) || !latestDate) {
+                latestDate = latestDateForSection;
+            }
         }
     }
 
@@ -900,11 +912,15 @@ NSUInteger const INSEPGLayoutMinBackgroundZ = 0.0;
 
     NSDate *latestDate = nil;
 
-    for (NSInteger item = 0; item < [self.collectionView numberOfItemsInSection:section]; item++) {
-        NSIndexPath *indexPath = [NSIndexPath indexPathForItem:item inSection:section];
-        NSDate *itemEndDate = [self endDateForIndexPath:indexPath];
-        if ((itemEndDate && [itemEndDate ins_isLaterThan:latestDate]) || !latestDate) {
-            latestDate = itemEndDate;
+    if ([self.dataSource respondsToSelector:@selector(fixedEndTimeForcollectionView:layout:)]) {
+        latestDate = [self.dataSource fixedEndTimeForcollectionView:self.collectionView layout:self];
+    } else {
+        for (NSInteger item = 0; item < [self.collectionView numberOfItemsInSection:section]; item++) {
+            NSIndexPath *indexPath = [NSIndexPath indexPathForItem:item inSection:section];
+            NSDate *itemEndDate = [self endDateForIndexPath:indexPath];
+            if ((itemEndDate && [itemEndDate ins_isLaterThan:latestDate]) || !latestDate) {
+                latestDate = itemEndDate;
+            }
         }
     }
 


### PR DESCRIPTION
Hi,
  this is my very first pull request, so be patient (and let me know if I'm doing something wrong). 

  I'm using your layout and it is very cool. The only downside in my case was that I need to show events in a specific interval of time but I want to show that interval even if there's no event at all (so it would be a completely empty grid). At the moment the starting and ending time to show is calculated from the starting/ending date for each event. In this way what I want to achieve is not possible.

  My solution is to extend the datasource to have to more optional methods. These methods ask for a fixed starting and ending date. When these two methods are implemented, they override the normal behaviour.

  I really hope I explained myself well.
