### PR TITLE
Add Boolean to indicate if currentTimeVerticalGridLine should be behind

### DIFF
--- a/INSElectronicProgramGuideLayout/INSElectronicProgramGuideLayout.h
+++ b/INSElectronicProgramGuideLayout/INSElectronicProgramGuideLayout.h
@@ -74,6 +74,12 @@ typedef NS_ENUM(NSUInteger, INSElectronicProgramGuideLayoutType) {
 @property (nonatomic, assign) CGFloat currentTimeVerticalGridlineWidth;
 
 /**
+ *  Current time indicator zIndex
+ */
+@property (nonatomic, assign) BOOL currentTimeIndicatorShouldBeBehind;
+
+
+/**
  *  Gridlines size
  */
 @property (nonatomic, assign) CGFloat horizontalGridlineHeight;

--- a/INSElectronicProgramGuideLayout/INSElectronicProgramGuideLayout.m
+++ b/INSElectronicProgramGuideLayout/INSElectronicProgramGuideLayout.m
@@ -185,6 +185,9 @@ NSUInteger const INSEPGLayoutMinBackgroundZ = 0.0;
     self.floatingItemOffsetFromSection = 10.0;
     self.shouldResizeStickyHeaders = NO;
 
+    // Set CurrentTime Behind cell
+    self.currentTimeIndicatorShouldBeBehind = YES;
+
     self.headerLayoutType = INSElectronicProgramGuideLayoutTypeTimeRowAboveDayColumn;
 
     // Invalidate layout on minute ticks (to update the position of the current time indicator)

--- a/INSElectronicProgramGuideLayout/INSElectronicProgramGuideLayout.m
+++ b/INSElectronicProgramGuideLayout/INSElectronicProgramGuideLayout.m
@@ -821,7 +821,11 @@ NSUInteger const INSEPGLayoutMinBackgroundZ = 0.0;
     }
     // Current Time Horizontal Gridline
     else if (elementKind == INSEPGLayoutElementKindCurrentTimeIndicatorVerticalGridline) {
-        return (INSEPGLayoutMinBackgroundZ + 2.0);
+        if (self.currentTimeIndicatorShouldBeBehind) {
+            return (INSEPGLayoutMinBackgroundZ + 2.0);
+        }
+        // Place currentTimeGridLine juste behind Section Header and above cell
+        return (INSEPGLayoutMinOverlayZ + ((self.headerLayoutType == INSElectronicProgramGuideLayoutTypeTimeRowAboveDayColumn) ? (floating ? 5.9 : 0.9) : (floating ? 8.9 : 3.9)));
     }
     // Vertical Gridline
     else if (elementKind == INSEPGLayoutElementKindVerticalGridline || elementKind == INSEPGLayoutElementKindHalfHourVerticalGridline) {


### PR DESCRIPTION
Add boolean to allow users to put currentTimeVerticalGridLine in front of the cell. By default, the currentTimeVerticalGridLine stand behind as before.
