### PR TITLE
Add target to Podfile

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,8 +1,10 @@
 platform :ios, "7.0"
 
-pod 'MagicalRecord'
-pod 'UIColor+MLPFlatColors'
-pod 'LoremIpsum'
+target 'INSElectronicProgramGuideLayout' do
+  pod 'MagicalRecord'
+  pod 'UIColor+MLPFlatColors'
+  pod 'LoremIpsum'
+end
 
 inhibit_all_warnings!
 


### PR DESCRIPTION
Without the target, CocoPods complains:

> The dependency [name] is not used in any concrete target.
